### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/main.py
+++ b/main.py
@@ -104,11 +104,11 @@ if __name__=="__main__":
 
     elif op == "xlsx_similarity": 
         startTime = time.time()
-        SimilarityRatio(files_path.xlsx,"xlsx",method="fuzzywuzzy")
+        SimilarityRatio(files_path.xlsx,"xlsx",method="rapidfuzz")
 
     elif op == "pptx_similarity": 
         startTime = time.time()
-        SimilarityRatio(files_path.pptx,"pptx",method="fuzzywuzzy")
+        SimilarityRatio(files_path.pptx,"pptx",method="rapidfuzz")
 
     elif op == "txt_class_txt": 
         startTime = time.time()

--- a/main_gui.py
+++ b/main_gui.py
@@ -127,7 +127,7 @@ class Window(QMainWindow):
         if not f1 or not f2:
             self.statusBar().showMessage('Action Cancelled')
         else:
-            SimilarityRatio([f1,f2],tmp,method="fuzzywuzzy")
+            SimilarityRatio([f1,f2],tmp,method="rapidfuzz")
     
     def doc_classify(self):
         tmp = self.table_widget.control1_wid.combo_box.currentText()

--- a/pardus.yml
+++ b/pardus.yml
@@ -58,7 +58,6 @@ dependencies:
     - ebooklib==0.15
     - et-xmlfile==1.0.1
     - eyed3==0.8.10
-    - fuzzywuzzy==0.17.0
     - gast==0.2.2
     - gensim==3.7.3
     - grpcio==1.20.1
@@ -108,12 +107,12 @@ dependencies:
     - pytesseract==0.2.6
     - python-dateutil==2.8.0
     - python-docx==0.8.10
-    - python-levenshtein==0.12.0
     - python-magic==0.4.15
     - python-pptx==0.6.5
     - pytz==2019.1
     - pywavelets==1.0.3
     - pyyaml==5.1
+    - rapidfuzz==0.7.3
     - requests==2.21.0
     - s3transfer==0.2.0
     - scikit-image==0.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,6 @@ dynamic-reconfigure==1.6.0
 EbookLib==0.15
 et-xmlfile==1.0.1
 eyeD3==0.8.10
-fuzzywuzzy==0.17.0
 gast==0.2.2
 gazebo-plugins==2.8.4
 gazebo-ros==2.8.4
@@ -97,7 +96,6 @@ pyplantuml==0.1.51
 pytesseract==0.2.6
 python-dateutil==2.8.0
 python-docx==0.8.10
-python-Levenshtein==0.12.0
 python-magic==0.4.15
 python-pptx==0.6.5
 python-qt-binding==0.3.5
@@ -108,6 +106,7 @@ qt-dotgraph==0.3.11
 qt-gui==0.3.11
 qt-gui-cpp==0.3.11
 qt-gui-py-common==0.3.11
+rapidfuzz==0.7.3
 requests==2.21.0
 resource-retriever==1.12.4
 rosbag==1.14.3

--- a/similarity.py
+++ b/similarity.py
@@ -11,8 +11,7 @@ from os import listdir
 from os.path import isfile, join
 from db_handler import *
 from open_files import OpenFile
-from fuzzywuzzy import fuzz
-from fuzzywuzzy import process
+from rapidfuzz import fuzz
 
 from sklearn.preprocessing import StandardScaler
 from sklearn.cluster import AffinityPropagation
@@ -89,7 +88,7 @@ class SimilarityRatio():
                     data.append("")
 
         data = nlp_clean(data)
-        if method == "fuzzywuzzy":
+        if method == "rapidfuzz":
             for i, f1 in enumerate(data):
                 for f2 in data[i+1:]:
                     # print(self.docLabels[i],self.docLabels[i+1])


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/maxbachmann/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy